### PR TITLE
Install jotai, create username as an example of how to use caching & atoms

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "axios": "^1.6.8",
         "cheerio": "^1.0.0-rc.12",
         "framer-motion": "^11.1.7",
+        "jotai": "^2.8.0",
         "next": "14.2.3",
         "react": "^18",
         "react-dom": "^18"
@@ -4724,6 +4725,26 @@
       "dev": true,
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jotai": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.8.0.tgz",
+      "integrity": "sha512-yZNMC36FdLOksOr8qga0yLf14miCJlEThlp5DeFJNnqzm2+ZG7wLcJzoOyij5K6U6Xlc5ljQqPDlJRgqW0Y18g==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/js-tokens": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "axios": "^1.6.8",
     "cheerio": "^1.0.0-rc.12",
     "framer-motion": "^11.1.7",
+    "jotai": "^2.8.0",
     "next": "14.2.3",
     "react": "^18",
     "react-dom": "^18"

--- a/frontend/src/app/lib/atoms/usernameAtom.ts
+++ b/frontend/src/app/lib/atoms/usernameAtom.ts
@@ -1,0 +1,7 @@
+import { atomWithStorage } from 'jotai/utils'
+
+// establish a uniqie key for the cache
+const cacheKey = 'username';
+
+// create an atom with storage (will be persisted across refreshes)
+export const usernameAtom = atomWithStorage<string | null>(cacheKey, null);

--- a/frontend/src/app/ui/header.tsx
+++ b/frontend/src/app/ui/header.tsx
@@ -1,13 +1,17 @@
-import { Box, Heading } from '@chakra-ui/react'
+import { Flex, Heading } from '@chakra-ui/react'
 import React from 'react'
+import Profile from './profile'
 
-type Props = {}
-
-const Header = (props: Props) => {
+const Header = () => {
     return (
-        <Box p={'.5rem 1rem'}>
+        <Flex
+            p={'.5rem 1rem'}
+            justifyContent={"space-between"}
+            bgImage={'linear-gradient(#ffe5e5, white)'}
+        >
             <Heading>NextUp</Heading>
-        </Box>
+            <Profile />
+        </Flex>
     )
 }
 

--- a/frontend/src/app/ui/profile.tsx
+++ b/frontend/src/app/ui/profile.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Avatar, Editable, EditableInput, EditablePreview, Flex, useToast } from '@chakra-ui/react'
+import React from 'react'
+import { usernameAtom } from '../lib/atoms/usernameAtom';
+import { useAtom } from 'jotai';
+
+const Profile = () => {
+    const [username, setUsername] = useAtom(usernameAtom);
+    const toast = useToast();
+
+    return (
+        <Flex alignItems={'center'} gap={'1rem'}>
+            <Editable
+                value={username === null ? "Enter your name here!" : username}
+                onChange={(updated) => setUsername(updated)}
+                onSubmit={(updated) => {
+                    console.log("we've submitted")
+                    if (!updated) {
+                        updated = "User";
+                        setUsername(updated)
+                    }
+                    toast({
+                        title: `Welcome, ${updated}!`,
+                        description: "We've saved your username to your computer.",
+                        status: "success",
+                        duration: 2000,
+                        isClosable: true,
+                        position: 'top',
+                    })
+                }}
+            >
+                <EditablePreview {...editableStyles} />
+                <EditableInput {...editableStyles} />
+            </Editable>
+            <Avatar name={username || "?"} />
+        </Flex>
+    )
+}
+
+const editableStyles = {
+    bg: "#e0e0e0ff",
+    p: ".2rem .8rem",
+    borderRadius: "5px"
+}
+
+export default Profile


### PR DESCRIPTION
I've installed `jotai`, a package that can help store state locally in the user's cache with the `atomWithStorage` utility.

Some background:
* Jotai is an atomic state manager. It's kind of like using React's useState, but instead of defining your state in a component,  you define it in a separate file. Here, `usernameAtom.ts`. 
* You can access an atom with the `useAtom` hook. It returns an array, the first object is the value, and the second object is the function to update the value. Check out `profile.tsx` to see an example. 

This should be a good guide as to how to store a user's completed classes across refreshes, for when we're ready.